### PR TITLE
avoid ArgumentOutOfRangeException when ship has 0 parts (post-explosion)

### DIFF
--- a/DischargeCapacitorUI.cs
+++ b/DischargeCapacitorUI.cs
@@ -230,6 +230,11 @@ namespace NearFutureElectrical
 
         private float getTotalEc()
         {
+            if (FlightGlobals.ActiveVessel.parts.Count == 0)
+            {
+                return 0f;
+            }
+
             List<PartResource> resources = new List<PartResource>();
             FlightGlobals.ActiveVessel.parts[0].GetConnectedResources(PartResourceLibrary.Instance.GetDefinition("ElectricCharge").id, ResourceFlowMode.ALL_VESSEL, resources);
             float totalEc = 0f;
@@ -241,6 +246,11 @@ namespace NearFutureElectrical
         }
         private float getTotalSc()
         {
+            if (FlightGlobals.ActiveVessel.parts.Count == 0)
+            {
+                return 0f;
+            }
+
             List<PartResource> resources = new List<PartResource>();
             FlightGlobals.ActiveVessel.parts[0].GetConnectedResources(PartResourceLibrary.Instance.GetDefinition("StoredCharge").id, ResourceFlowMode.ALL_VESSEL, resources);
             float totalEc = 0f;


### PR DESCRIPTION
I had a ship (with no NFT parts) explode, after which the KSP log was filled with tons of these:

```
ArgumentOutOfRangeException: Argument is out of range.
Parameter name: index
  at System.Collections.Generic.List`1[Part].get_Item (Int32 index) [0x00000] in <filename unknown>:0 
  at NearFutureElectrical.DischargeCapacitorUI.getTotalEc () [0x00000] in <filename unknown>:0 
  at NearFutureElectrical.DischargeCapacitorUI.FixedUpdate () [0x00000] in <filename unknown>:0 
```

After the ship exploded, there were 0 parts remaining, but `DischargeCapacitorUI` keeps trying to access `FlightGlobals.ActiveVessel.parts[0]` on every `FixedUpdate`.

I patched `getTotalEc` and `getTotalSc` so they won't continually throw exceptions in this case.
