### PR TITLE
Fix capacitor empty discharge

### DIFF
--- a/DischargeCapacitor.cs
+++ b/DischargeCapacitor.cs
@@ -155,8 +155,7 @@ namespace NearFutureElectrical
         }
         public override void OnFixedUpdate()
         {
-            // Only attempt to discharge if there is charge available
-            if (Discharging && CurrentCharge > 0f)
+            if (Discharging)
             {
                 foreach (AnimationState cState in capacityState)
                 {
@@ -165,9 +164,10 @@ namespace NearFutureElectrical
                 }
 
 
-                float amt = TimeWarp.fixedDeltaTime * (dischargeSlider/100f )* DischargeRate;
-                    
-                this.part.RequestResource("StoredCharge", amt);
+                float requested_amt = TimeWarp.fixedDeltaTime * (dischargeSlider/100f )* DischargeRate;
+
+                // Don't try to insert more ElectricCharge than there was StoredCharge available
+                float amt = this.part.RequestResource("StoredCharge", requested_amt);
                 this.part.RequestResource("ElectricCharge", -amt);
 
                 CapacitorStatus = String.Format("Discharging: {0:F2}/s", DischargeRate*(dischargeSlider / 100f));
@@ -200,7 +200,6 @@ namespace NearFutureElectrical
             else if (CurrentCharge == 0f)
             {
                 CapacitorStatus = "Discharged!";
-                Discharging = false;
             } else 
             {
                 CapacitorStatus = String.Format("Ready");

--- a/DischargeCapacitor.cs
+++ b/DischargeCapacitor.cs
@@ -155,7 +155,8 @@ namespace NearFutureElectrical
         }
         public override void OnFixedUpdate()
         {
-            if (Discharging)
+            // Only attempt to discharge if there is charge available
+            if (Discharging && CurrentCharge > 0f)
             {
                 foreach (AnimationState cState in capacityState)
                 {
@@ -199,6 +200,7 @@ namespace NearFutureElectrical
             else if (CurrentCharge == 0f)
             {
                 CapacitorStatus = "Discharged!";
+                Discharging = false;
             } else 
             {
                 CapacitorStatus = String.Format("Ready");


### PR DESCRIPTION
When discharging a capacitor, don't insert more ElectricCharge than StoredCharge removed from the capacitor.

Chris, this issue can also be fixed with the changes in 3958309 if you don't want the GUI to flicker between "Discharging X EC/s" and "Discharged" each time the user clicks the Discharge button. I did not keep those changes after fixing the amount of EC actually inserted into the craft, as I didn't really like the lack of any feedback when clicking "Discharge" on an empty cap. With f3e62c5, it tries to discharge but has no StoredCharge available so quickly disables itself (while never actually making phantom EC). 

Either way, the amount of EC needed to be limited to prevent a near-empty capacitor from making phantom EC.