### PR TITLE
Fix for 1.0.5

### DIFF
--- a/FissionReactor.cs
+++ b/FissionReactor.cs
@@ -389,8 +389,6 @@ namespace NearFutureElectrical
                 return "A long time!";
             }
             double remaining = amount / rate;
-            TimeSpan t = TimeSpan.FromSeconds(remaining);
-
             if (remaining >= 0)
             {
                 return Utils.FormatTimeString(remaining);

--- a/FissionReactor.cs
+++ b/FissionReactor.cs
@@ -223,7 +223,7 @@ namespace NearFutureElectrical
             }
         }
 
-        private void FixedUpdate()
+        private new void FixedUpdate()
         {
             if (HighLogic.LoadedScene == GameScenes.FLIGHT)
             {
@@ -316,6 +316,7 @@ namespace NearFutureElectrical
 
                 
             }
+	    base.FixedUpdate();
         }
 
         private void RecalculateRatios(float powerInputScale, float fuelInputScale)

--- a/RadioactiveStorageContainer.cs
+++ b/RadioactiveStorageContainer.cs
@@ -237,7 +237,7 @@ namespace NearFutureElectrical
                     {
                         // get available space in the target container
                         double availableSpace = container.GetResourceAmount(curTransferType, true) - container.GetResourceAmount(curTransferType);
-                        double availableResource = this.GetResourceAmount(curTransferType);
+//                        double availableResource = this.GetResourceAmount(curTransferType);
 
                         // transfer as much as possible
                         double amount = this.part.RequestResource(curTransferType, availableSpace);


### PR DESCRIPTION
I got the following warnings compiling against 1.0.5:

FissionReactor.cs(226,22): warning CS0108: `NearFutureElectrical.FissionReactor.FixedUpdate()' hides inherited member `BaseConverter.FixedUpdate()'. Use the new keyword if hiding was intended
/Users/sommerfeld/Library/Application Support/Steam/SteamApps/common/Kerbal Space Program/KSP.app/Contents/Data/Managed/Assembly-CSharp.dll (Location of the symbol related to previous warning)
FissionReactor.cs(392,22): warning CS0219: The variable `t' is assigned but its value is never used
RadioactiveStorageContainer.cs(240,32): warning CS0219: The variable `availableResource' is assigned but its value is never used
Compilation succeeded - 3 warning(s)

the two commits appear to have silenced the warning and made the reactor work again.