### PR TITLE
Allow reactor power to follow throttle

### DIFF
--- a/Source/FissionEngine.cs
+++ b/Source/FissionEngine.cs
@@ -85,7 +85,7 @@ namespace NearFutureElectrical
                     else
                     {
                         float CoreTemperatureRatio = TempIspScale.Evaluate((float)core.CoreTemperature);
-                        float reactorRatio = reactor.CurrentPowerPercent / 100f;
+                        float reactorRatio = reactor.ActualPowerPercent / 100f;
                         if (!reactor.ModuleIsActive())
                             reactorRatio = 0f;
 
@@ -102,7 +102,7 @@ namespace NearFutureElectrical
                     }
                    
                 }
-                float heat = reactor.CurrentPowerPercent / 100f * reactor.HeatGeneration / 50f * reactor.CoreIntegrity / 100f;
+                float heat = reactor.ActualPowerPercent / 100f * reactor.HeatGeneration / 50f * reactor.CoreIntegrity / 100f;
                 flowRadiator.ChangeRadiatorTransfer(Mathf.Max(base.CurrentHeatUsed, heat) * maxFlowScalar);
             }
 

--- a/Source/FissionReactor.cs
+++ b/Source/FissionReactor.cs
@@ -30,6 +30,10 @@ namespace NearFutureElectrical
         /// CONFIGURABLE FIELDS
         // ----------------------
 
+        // Whether reactor power settings should follow the throttle setting
+        [KSPField(isPersistant = false)]
+        public bool FollowThrottle = false;
+
         // Whether to use a staging icon or not
         [KSPField(isPersistant = false)]
         public bool UseStagingIcon = true;
@@ -61,6 +65,10 @@ namespace NearFutureElectrical
         // Current reactor power setting (0-100, tweakable)
         [KSPField(isPersistant = true, guiActive = true, guiName = "Power Setting"), UI_FloatRange(minValue = 0f, maxValue = 100f, stepIncrement = 1f)]
         public float CurrentPowerPercent = 100f;
+
+        // Actual reactor power setting used (0-100, read-only)
+        [KSPField(isPersistant = false)]
+        public float ActualPowerPercent = 100f;
 
         // Curve relating available power to temperature. Generally should be of the form
         // AmbientTemp  0
@@ -166,6 +174,8 @@ namespace NearFutureElectrical
         private List<ResourceBaseRatio> inputs;
         private List<ResourceBaseRatio> outputs;
 
+        private FloatCurve throttleCurve;
+
         /// UI FIELDS
         /// --------------------
 
@@ -224,6 +234,11 @@ namespace NearFutureElectrical
 
         public override void OnStart(PartModule.StartState state)
         {
+
+            throttleCurve = new FloatCurve();
+            throttleCurve.Add(0, 0, 0, 0);
+            throttleCurve.Add(70, 10, 0, 0);
+            throttleCurve.Add(100, 100, 0, 0);
 
             if (UseStagingIcon)
             {
@@ -294,6 +309,13 @@ namespace NearFutureElectrical
             base.OnFixedUpdate();
             if (HighLogic.LoadedScene == GameScenes.FLIGHT)
             {
+                if (FollowThrottle)
+                {
+                    ActualPowerPercent = Math.Max(throttleCurve.Evaluate(100 * this.vessel.ctrlState.mainThrottle), CurrentPowerPercent);
+                }
+                else {
+                    ActualPowerPercent = CurrentPowerPercent;
+                }
 
                 // Update reactor core integrity readout
                 if (CoreIntegrity > 0)
@@ -348,7 +370,7 @@ namespace NearFutureElectrical
           }
           // Recalculate fuel use Ratio
           // Fuel use is proportional to power setting
-          RecalculateRatios(CurrentPowerPercent / 100f );
+          RecalculateRatios(ActualPowerPercent / 100f );
 
           // Find the time remaining at current rate
           FuelStatus = FindTimeRemaining(
@@ -360,7 +382,7 @@ namespace NearFutureElectrical
         private void DoHeatGeneration()
         {
             // Generate heat from the reaction and apply it
-            SetHeatGeneration((CurrentPowerPercent / 100f * HeatGeneration)* CoreIntegrity/100f);
+            SetHeatGeneration((ActualPowerPercent / 100f * HeatGeneration)* CoreIntegrity/100f);
 
             if (CoreIntegrity <= 0f)
             {
@@ -369,7 +391,7 @@ namespace NearFutureElectrical
             }
             else
             {
-                ReactorOutput = String.Format("{0:F1} kW", CurrentPowerPercent / 100f * HeatGeneration / 50f * CoreIntegrity / 100f);
+                ReactorOutput = String.Format("{0:F1} kW", ActualPowerPercent / 100f * HeatGeneration / 50f * CoreIntegrity / 100f);
             }
         }
 
@@ -383,7 +405,7 @@ namespace NearFutureElectrical
         {
             // save some divisions later
             float coreIntegrity = CoreIntegrity / 100f;
-            float reactorThrottle = CurrentPowerPercent / 100f;
+            float reactorThrottle = ActualPowerPercent / 100f;
             if (!base.ModuleIsActive())
                 reactorThrottle = 0f;
             float maxHeatGenerationKW = HeatGeneration / 50f;
@@ -458,7 +480,7 @@ namespace NearFutureElectrical
             // The allowed maximum radiator cooling. Should not exceed the heat generation 
             float coolingCap = HeatGeneration / 50f;
           
-            float maxRadiatorCooling = Mathf.Clamp(curTempScale * (HeatGeneration / 50f) * (CoreIntegrity/100f) *(CurrentPowerPercent/100f),
+            float maxRadiatorCooling = Mathf.Clamp(curTempScale * (HeatGeneration / 50f) * (CoreIntegrity/100f) *(ActualPowerPercent/100f),
                 0f, 
                 coolingCap);            
             
@@ -552,7 +574,7 @@ namespace NearFutureElectrical
             {
                 reactorFudgeFactor = 0f;
             }
-            
+
             TemperatureModifier = new FloatCurve();
             TemperatureModifier.Add(0f, heat + reactorFudgeFactor * 50f);
 

--- a/Source/ReactorUI.cs
+++ b/Source/ReactorUI.cs
@@ -218,7 +218,13 @@ namespace NearFutureElectrical
             //GUILayout.Label("Core Temperature", gui_text, GUILayout.MaxWidth(150f), GUILayout.MinWidth(150f));
             GUILayout.BeginHorizontal();
 
+            GUILayout.BeginVertical();
             GUILayout.Label("Reactor Status", gui_header2, GUILayout.MaxWidth(110f), GUILayout.MinWidth(110f));
+            if (reactor.FollowThrottle)
+            {
+                GUILayout.Label(String.Format("Actual: {0:F0}%", reactor.ActualPowerPercent), gui_text);
+            }
+            GUILayout.EndVertical();
 
             GUILayout.BeginVertical();
             GUILayout.BeginHorizontal();


### PR DESCRIPTION
Creates a second variable "ActualReactorPower" and modifies it based on throttle, if the reactor is tagged to do so (such as Kerbal Atomics engines).

Not a 1:1 relationship, but rather a conservative power curve.

![](http://i.imgur.com/WUTcwWN.png)

![](http://i.imgur.com/Y7iHF3W.png)

Note the Power Setting is set to 4%, navball throttle is like 80%, and actual power setting is 37%.  Throttle and actual power only match at 0% and 100%.

Because the curve is *very* conservative, you'll still get better performance if you manually babysit the Power Setting at the same time as the throttle.

Importantly, this keeps the ISP/thrust relationship to power consumption.  You'll be burning lots of EnrichedUranium at 100%, and you'll still pay a penalty for operating the reactor at less than 100%.  You just won't have to manage two levers at once (throttle and Power Setting), and MechJeb can once again fly your ship without destroying it. :)