### PR TITLE
Whirlijig MKS patch tweaks

### DIFF
--- a/GameData/NearFutureElectrical/Patches/NFElectricalUSI.cfg
+++ b/GameData/NearFutureElectrical/Patches/NFElectricalUSI.cfg
@@ -904,7 +904,9 @@
 
 @PART[nuclear-recycler-25]:NEEDS[MKS]
 {
-	!MODULE[ModuleResourceConverter],2{}
+	// MKS has a different way of producing EnrichedUranium, from Uraninite,
+	// so producing it from Ore isn't appropriate.
+	!MODULE[ModuleResourceConverter],2{}  // Ore->EnrichedUranium
 	@description,0 ^= :both process Ore into Enriched Uranium and ::
 }
 

--- a/GameData/NearFutureElectrical/Patches/NFElectricalUSI.cfg
+++ b/GameData/NearFutureElectrical/Patches/NFElectricalUSI.cfg
@@ -905,6 +905,7 @@
 @PART[nuclear-recycler-25]:NEEDS[MKS]
 {
 	!MODULE[ModuleResourceConverter],2{}
+	@description,0 ^= :both process Ore into Enriched Uranium and ::
 }
 
 @PART[nuclearfuel-0625]:NEEDS[000_USITools]

--- a/GameData/NearFutureElectrical/Patches/NFElectricalUSI.cfg
+++ b/GameData/NearFutureElectrical/Patches/NFElectricalUSI.cfg
@@ -906,7 +906,7 @@
 {
 	// MKS has a different way of producing EnrichedUranium, from Uraninite,
 	// so producing it from Ore isn't appropriate.
-	!MODULE[ModuleResourceConverter],2{}  // Ore->EnrichedUranium
+	!MODULE[ModuleResourceConverter]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[Ore]]&@OUTPUT_RESOURCE:HAS[#ResourceName[EnrichedUranium]]]{}
 	@description,0 ^= :both process Ore into Enriched Uranium and ::
 }
 


### PR DESCRIPTION
The Whirlijig's Ore→EnrichedUranium converter is disabled when MKS is installed (since MKS has a different way of producing EnrichedUranium), but it was still mentioned in the part's description, and this recently confused someone in the forum.  I realized that it's easy to remove that portion of the description with a regex in the MM patch, so I did.

I also changed the patch to look specifically for a converter whose `INPUT_RESOURCE` is Ore and whose `OUTPUT_RESOURCE` is EnrichedUranium, instead of just removing the part's third resource converter (whatever it may be).  This avoids potential problems in the future if modules are added or removed so that the Ore→EnrichedUranium converter ends up at a different index.  (It also makes it more clear exactly what converter the patch is removing.)