### PR TITLE
Give NF radial capacitors PhysicsSignificance = 1

### DIFF
--- a/GameData/NearFutureElectrical/Parts/Capacitors/capacitor-rad-0625-2/capacitor-rad-0625-2.cfg
+++ b/GameData/NearFutureElectrical/Parts/Capacitors/capacitor-rad-0625-2/capacitor-rad-0625-2.cfg
@@ -36,9 +36,10 @@ PART
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
+	PhysicsSignificance = 1
 
 	tags = capacitor cell charge e/c elect pack power volt watt nearfuture
-	
+
 	MODULE
 	{
 		name = DischargeCapacitor

--- a/GameData/NearFutureElectrical/Parts/Capacitors/capacitor-rad-0625/capacitor-rad-0625.cfg
+++ b/GameData/NearFutureElectrical/Parts/Capacitors/capacitor-rad-0625/capacitor-rad-0625.cfg
@@ -37,6 +37,7 @@ PART
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
+	PhysicsSignificance = 1
 
 	tags = capacitor cell charge e/c elect pack power volt watt nearfuture
 


### PR DESCRIPTION
I was playing around with the Near Future mods, making myself a nice interplanetary mothership (and really loving the Magnetoplasmadynamic engines!) and I noticed that the Near Future RCS thruster parts did not have PhysicsSignificance = 1 set, while all the stock RCS thruster parts do.

It seems the stock game makes RCS ports and other such low-mass parts "physicsless" for performance reasons, and I decided to test if this was in fact the case. I set up a huge ship with 296 parts, 94 of them being NF RCS thrusters. When changing them to "PhysicsSignificance = 1", I observed a 10% improvement in physics frame updating as measured by the MemGraph mod.

As such, I've given all the RCS blocks across the NF mods PhysicsSignificance = 1, as well as the Atmospheric Sounder part and the radially-attachable Capacitors from NF Electrical, as they are very similar to the stock science experiment parts and radial batteries, respectively, which are also "physicsless".

(This message accompanies three pull requests for NF Propulsion, NF Electrical, and NF Spacecraft.)