### PR TITLE
Add CTT patch for Hermes reactor

### DIFF
--- a/GameData/NearFutureElectrical/Patches/NFElectricalCommunityTechTree.cfg
+++ b/GameData/NearFutureElectrical/Patches/NFElectricalCommunityTechTree.cfg
@@ -19,6 +19,10 @@
 {
 	@TechRequired = advNuclearPower
 }
+@PART[reactor-375-2]:NEEDS[CommunityTechTree]
+{
+	@TechRequired = advNuclearPower
+}
 
 // RTG
 @PART[rtg-0625]:NEEDS[CommunityTechTree]


### PR DESCRIPTION
The new Hermes reactor was hanging out in "Very Heavy Rocketry" even with CTT installed, so I've moved it to "High Energy Nuclear Power" where it can keep the Excalibur and F.L.A.T. company.