### PR TITLE
Draft russian translation 0.3

### DIFF
--- a/GameData/NearFutureElectrical/Localization/ru.cfg
+++ b/GameData/NearFutureElectrical/Localization/ru.cfg
@@ -1,4 +1,4 @@
-﻿// Draft translation v.0.1		(some questionable things and no tags)
+﻿// Draft translation v.0.2		(no tags)
 // © Dr. Jet
 
 Localization
@@ -34,49 +34,49 @@ Localization
     #LOC_NFElectrical_battery-375_description = Похоже, что без спроса на сверхкрупные модули, вызванного продукцией «Кербодайн», B-10K так и остались бы мечтой в голове Бандаса Кермана. Инновационная система заменяемых клинообразных блоков аккумуляторов позволяет хранить огромный электрический заряд.
     #LOC_NFElectrical_battery-375_tags = cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_battery-rad-125_title = Блок аккумуляторов B-800 
-    #LOC_NFElectrical_battery-rad-125_description = После крушения проекта "летающей доски" Бат-Директ, которое связывают с периодическими мощными вспышками пламени, компания обнаружила, что у неё есть большой запас крупных и мощных аккумуляторов для скутеров. Разве найдётся для них лучшее использование чем в зарождающейся космической программе?
+    #LOC_NFElectrical_battery-rad-125_description = После крушения проекта «летающей доски» Бат-Директ, которое связывают с периодическими мощными вспышками пламени, компания обнаружила, что у неё есть большой запас крупных и мощных аккумуляторов для скутеров. Разве найдётся для них лучшее использование чем в зарождающейся космической программе?
     #LOC_NFElectrical_battery-rad-125_tags = cell charge e/c elect pack power volt watt nearfuture
 
     // Capacitors
-    #LOC_NFElectrical_capacitor-0625_title = Блок конденсаторов CAR-1.6K 
-    #LOC_NFElectrical_capacitor-0625_description =  Встроенный конденсатор для небольших зондов. Перезаряжается медленно - активируйте для получения большого, но краткосрочного заряда.
+    #LOC_NFElectrical_capacitor-0625_title = Блок накопителей CAR-1.6K 
+    #LOC_NFElectrical_capacitor-0625_description =  Встроенный накопитель для небольших зондов. Перезаряжается медленно - активируйте для получения большого, но краткосрочного заряда.
     #LOC_NFElectrical_capacitor-0625_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
-    #LOC_NFElectrical_capacitor-125_title = Блок конденсаторов CAR-8K
-    #LOC_NFElectrical_capacitor-125_description = Разместив 6 улучшенных CAP-102 на центральной опоре, можно создать встроенный блок конденсаторов приличного размера. Дополнительно, он может с лёгкостью погасить все огни в ЦУПе!
+    #LOC_NFElectrical_capacitor-125_title = Блок накопителей CAR-8K
+    #LOC_NFElectrical_capacitor-125_description = Разместив 6 улучшенных CAP-102 на центральной опоре, можно создать встроенный блок накопителей приличного размера. Дополнительно, он может с лёгкостью погасить все огни в ЦУПе!
     #LOC_NFElectrical_capacitor-125_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
-    #LOC_NFElectrical_capacitor-25_title = Блок конденсаторов CAR-EXTRA 
-    #LOC_NFElectrical_capacitor-25_description = Это мощный блок конденсаторов, который может сбросить достаточный заряд, чтобы даже самые большие двигатели проработали целых... э-э-э... 10 секунд.
+    #LOC_NFElectrical_capacitor-25_title = Блок накопителей CAR-EXTRA 
+    #LOC_NFElectrical_capacitor-25_description = Это мощный блок накопителей, который может сбросить достаточный заряд, чтобы даже самые большие двигатели проработали целых... э-э-э... 10 секунд.
     #LOC_NFElectrical_capacitor-25_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_capacitor-radial-0625_title = Конденсатор CAP-101
-    #LOC_NFElectrical_capacitor-radial-0625_description =  CAP-101 - это конденсатор поверхностного монтажа. Заряжается медленно, но когда переключится, то быстро передаст всё накопленное электричество вашей системе аккумуляторов.
+    #LOC_NFElectrical_capacitor-radial-0625_description =  CAP-101 - это накопитель для поверхностного монтажа. Заряжается медленно, но когда переключится, то быстро передаст всё накопленное электричество вашей системе аккумуляторов.
     #LOC_NFElectrical_capacitor-radial-0625_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_capacitor-radial-0625-2_title = Конденсатор CAP-106
-    #LOC_NFElectrical_capacitor-radial-0625-2_description = CAP-106 это более мощный конденсатор поверхностного монтажа, использующий три новых модуля CAP-3A. Они слегка сплющены после того как полежали под несколькими ящиками с "Грохотами".
+    #LOC_NFElectrical_capacitor-radial-0625-2_description = CAP-106 это более мощный накопитель для поверхностного монтажа, использующий три новых модуля CAP-3A. Они слегка сплющены после того как полежали под несколькими ящиками с «Грохотами«.
     #LOC_NFElectrical_capacitor-radial-0625-2_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
 
     // Reactors
-    #LOC_NFElectrical_reactor-0625_title = MX-0 Ядерный реактор "КербоМощь"
+    #LOC_NFElectrical_reactor-0625_title = MX-0 Ядерный реактор «КербоМощь»
     #LOC_NFElectrical_reactor-0625_description = Малый экспериментальный ядерный реактор, использующий двигатель Стирлинга и ограниченную реакцию распада для производства нескольких киловатт электроэнергии. Сделать его чуть больше - и у нас уже будет полноценный реактор!
     #LOC_NFElectrical_reactor-0625_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission kilopower
-    #LOC_NFElectrical_reactor-125_title = MX-1 Ядерный реактор "Гранат"
+    #LOC_NFElectrical_reactor-125_title = MX-1 Ядерный реактор «Гранат»
     #LOC_NFElectrical_reactor-125_description = MX-1 это компактный ядерный реактор, производящий до 400 кВт электроэнергии. Перед запуском убедитесь, что подключили к нему достаточно радиаторов!
     #LOC_NFElectrical_reactor-125_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission topaz safe
-    #LOC_NFElectrical_reactor-25_title = MX-2S Ядерный реактор "Прометей"
+    #LOC_NFElectrical_reactor-25_title = MX-2S Ядерный реактор «Прометей»
     #LOC_NFElectrical_reactor-25_description = Ядерный реактор MX-2S это рабочая лошадка, производящая шокирующие 2 МВт электроэенергии. Ничем не выдающийся, но всё же шаг по дороге к величию.
     #LOC_NFElectrical_reactor-25_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
-    #LOC_NFElectrical_reactor-25-2_title =  MX-2L Ядерный реактор "Экскалибур"
+    #LOC_NFElectrical_reactor-25-2_title =  MX-2L Ядерный реактор «Экскалибур»
     #LOC_NFElectrical_reactor-25-2_description = Ядерный реактор MX-2L - второй по величине из доступных по площади. Он не только производит больше энергии чем родственный ему MX-2S, но и делает это с большей эффективностью, что выражается в меньшей массе необходимых радиаторов.
     #LOC_NFElectrical_reactor-25-2_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
-    #LOC_NFElectrical_reactor-375_title = MX-3S Ядерный реактор Б.Л.И.Н.
+    #LOC_NFElectrical_reactor-375_title = MX-3S Ядерный реактор «Б.Л.И.Н.»
     #LOC_NFElectrical_reactor-375_description = Успех усовершенствованных генераторов в MX-2L позволил производителям переделать старые ядра MX-2S и продавать их снова с улучшенной секцией генераторов. Б.Л.И.Н. - один из наиболее энергоэффективных и надёжных реакторов из когда-либо построенных, и сочетает это с чрезвычайно щедрой загрузкой ядерного топлива, что позволяет обеспечить беспрецедентный срок службы ядра.
     #LOC_NFElectrical_reactor-375_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
-    #LOC_NFElectrical_reactor-375-2_title = MX-3L Ядерный реактор "Гермес"
-    #LOC_NFElectrical_reactor-375-2_description = Масштабирование ядерных технологий совершенно иного порядка. Инженеры говорят, что это из области "долететь до Дюны за 30 дней на электрических двигателях".
+    #LOC_NFElectrical_reactor-375-2_title = MX-3L Ядерный реактор «Гермес»
+    #LOC_NFElectrical_reactor-375-2_description = Масштабирование ядерных технологий совершенно иного порядка. Инженеры говорят, что это из области «долететь до Дюны за 30 дней на электрических двигателях«.
     #LOC_NFElectrical_reactor-375-2_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
 
 
     // Resources
-    #LOC_NFElectrical_nuclear-recycler-25_title =  Обогатительная Центрифуга "Волчок"
+    #LOC_NFElectrical_nuclear-recycler-25_title =  Обогатительная Центрифуга «Волчок»
     #LOC_NFElectrical_nuclear-recycler-25_description = Эта центрифуга может перерабатывать как Руду, так и Отработанное Топливо в Обогащённый Уран или извлекать Ксенон как побочный продукт распада. Оба процесса потребляют большое количество энергии и требуют мощного охлаждения.
     #LOC_NFElectrical_nuclear-recycler-25_tags = conver isru mine )mining (ore process resource uranium refine reprocess nuclear nuke nearfuture
     #LOC_NFElectrical_nuclear-recycler-25_USI_description = Эта центрифуга может перерабатывать Отработанное Топливо в Обогащённый Уран или извлекать Ксенон как побочный продукт распада. Оба процесса потребляют большое количество энергии и требуют мощного охлаждения.
@@ -123,13 +123,13 @@ Localization
 	#LOC_NFElectrical_ModuleDischargeCapacitor_ModuleName = Конденсатор
 	#LOC_NFElectrical_ModuleDischargeCapacitor_PartInfo = Максимальный темп разряда: <<1>>ЭЭ/с \nТемп зарядки: <<2>>ЭЭ/с \nЭффективность: <<3>>%
 
-	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_ToggleUI = Переключить панель конденсатора
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_ToggleUI = Переключить панель накопителя
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_ToggleCharge = Переключить зарядку
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_EnableCharge = Разрешить зарядку
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_DisableCharge = Запретить зарядку
-	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_Discharge = Разрядить конденсатор
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_Discharge = Разрядить накопитель
 
-	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_Discharge = Разрядить конденсатор
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_Discharge = Разрядить накопитель
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_EnableCharge = Разрешить зарядку
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_DisableCharge = Запретить зарядку
 

--- a/GameData/NearFutureElectrical/Localization/ru.cfg
+++ b/GameData/NearFutureElectrical/Localization/ru.cfg
@@ -117,8 +117,13 @@ Localization
     #LOC_NFElectrical_rtg-0625_tags = active atom charge e/c elect energ generat isotope nuclear nuke power radio rtg thermo volt watt nearfuture
 
 
-
     // PLUGIN
+
+    #LOC_NFElectrical_Units_kW = кВт
+    #LOC_NFElectrical_Units_EcS = ЭЭ/с
+    #LOC_NFElectrical_Units_ScS = НЗ/с
+    #LOC_NFElectrical_Units_K = К
+	
     // ModuleDischargeCapacitor
 	#LOC_NFElectrical_ModuleDischargeCapacitor_ModuleName = Конденсатор
 	#LOC_NFElectrical_ModuleDischargeCapacitor_PartInfo = Максимальный темп разряда: <<1>>ЭЭ/с \nТемп зарядки: <<2>>ЭЭ/с \nЭффективность: <<3>>%
@@ -135,8 +140,8 @@ Localization
 
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_DischargeRate = Темп разряда
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status = Состояние
-	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Discharging = Разряжается
-	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Charging = Заряжается
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Discharging = Разряжается на <<1>> ЭЭ/с
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Charging = Заряжается на <<1>> ЭЭ/с
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_NoPower = Не хватает Электроэнергии!
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Ready = Готов
 	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Empty = Разряжен
@@ -179,6 +184,7 @@ Localization
 	#LOC_NFElectrical_ModuleFissionGenerator_ModuleName = Генератор реактора
 	#LOC_NFElectrical_ModuleFissionGenerator_PartInfo = Произведено энергии: <<1>> ЭЭ/с
 	#LOC_NFElectrical_ModuleFissionGenerator_Field_GeneratorStatus = Генерирует
+	#LOC_NFElectrical_ModuleFissionGenerator_Field_GeneratorStatus_Normal = <<1>> ЭЭ/с																				
 	#LOC_NFElectrical_ModuleFissionGenerator_Field_GeneratorStatus_Offline = Выключен
 
 	// FissionFlowRadiator
@@ -188,7 +194,7 @@ Localization
 
 	// RadioactiveStorageContainer
 	#LOC_NFElectrical_ModuleRadioactiveStorageContainer_ModuleName = Хранилище Ядерного Топлива
-  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_PartInfo = \n Позволяет хранить и перевозить радиоактивное топливо и отходы.
+	#LOC_NFElectrical_ModuleRadioactiveStorageContainer_PartInfo = \n Позволяет хранить и перевозить радиоактивное топливо и отходы.
   
   #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Event_TransferFuel = Переместить Топливо
   #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Event_TransferWaste = Переместить Отходы
@@ -204,8 +210,7 @@ Localization
   #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortNoPartSelected = Модуль не выбран, выходим из режима перемещения...
   #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortUnconnected = Нельзя переместить на несостыкованный аппарат, выходим из режима перемещения...
   #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortNoRadStorage = Выбранный модуль не может хранить радиоактивные материалы, выходим из режима перемещения...
-  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_Success = "<<1>> <<2>> перемещено в контейнер!
-
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_Success = <<1>> <<2>> перемещено в контейнер!
 
 	// RadioisotopeGenerator
 	#LOC_NFElectrical_ModuleRadioisotopeGenerator_ModuleName = Радиоизотопный Генератор

--- a/GameData/NearFutureElectrical/Localization/ru.cfg
+++ b/GameData/NearFutureElectrical/Localization/ru.cfg
@@ -1,0 +1,229 @@
+﻿// Draft translation v.0.1		(some questionable things and no tags)
+// © Dr. Jet
+
+Localization
+{
+  ru
+  {
+	#LOC_NFElectrical_Version = Near Future Electrical 0.9.0
+
+    // CONFIG
+    // MANUFACTURERS
+    #LOC_NFElectrical_manufacturer_kerbkastria_title = Корпорация Керб Кастрия
+    #LOC_NFElectrical_manufacturer_postkerbin_title = Пост-Кербин Добывающая Корпорация
+    #LOC_NFElectrical_manufacturer_battdirect_title = Батареи Бат-Директ 
+    #LOC_NFElectrical_manufacturer_capitalcity_title = Столичная Электроника
+
+    // VARIANTS
+    #LOC_NFElectrical_reactor_switcher_mount_title = Крепления
+    #LOC_NFElectrical_reactor_switcher_mount_variant1 = 2 точки
+    #LOC_NFElectrical_reactor_switcher_mount_variant2 = 1 точка
+
+    // PARTS
+    // Batteries
+    #LOC_NFElectrical_battery-0625_title = Блок аккумуляторов B-3K 
+    #LOC_NFElectrical_battery-0625_description = Лучший довод в пользу покупки B-3K это то, что он сделан из 28 аккумуляторов AAAA для надёжности. Обратите внимание, блок не будет работать при наличии неисправных аккумуляторов. Не пытайтесь доставать аккумуляторы во время работы.
+    #LOC_NFElectrical_battery-0625_tags = cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_battery-125_title = Блок аккумуляторов B-6K 
+    #LOC_NFElectrical_battery-125_description = B-6K в основном более надёжен чем B-3K, поскольку он использует в своей конструкции менее опасные аккумуляторы E. Бат-Директ также заявляет о заменяемости аккумуляторов, но не рекомендует заменять их кому-то кроме сотрудников Бат-Директ, а также - в космосе.
+    #LOC_NFElectrical_battery-125_tags = cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_battery-25_title = Блок аккумуляторов B-12K
+    #LOC_NFElectrical_battery-25_description = С целью ослабить Zаряд Электроникс, Батареи Бат-Директ начали продавать свои блоки аккумуляторов 12K  по демпинговым ценам прямо в ЦУП. В чём фишка товара? Встроенная лестница.
+    #LOC_NFElectrical_battery-25_tags = cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_battery-375_title = Блок аккумуляторов B-10K 
+    #LOC_NFElectrical_battery-375_description = Похоже, что без спроса на сверхкрупные модули, вызванного продукцией «Кербодайн», B-10K так и остались бы мечтой в голове Бандаса Кермана. Инновационная система заменяемых клинообразных блоков аккумуляторов позволяет хранить огромный электрический заряд.
+    #LOC_NFElectrical_battery-375_tags = cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_battery-rad-125_title = Блок аккумуляторов B-800 
+    #LOC_NFElectrical_battery-rad-125_description = После крушения проекта "летающей доски" Бат-Директ, которое связывают с периодическими мощными вспышками пламени, компания обнаружила, что у неё есть большой запас крупных и мощных аккумуляторов для скутеров. Разве найдётся для них лучшее использование чем в зарождающейся космической программе?
+    #LOC_NFElectrical_battery-rad-125_tags = cell charge e/c elect pack power volt watt nearfuture
+
+    // Capacitors
+    #LOC_NFElectrical_capacitor-0625_title = Блок конденсаторов CAR-1.6K 
+    #LOC_NFElectrical_capacitor-0625_description =  Встроенный конденсатор для небольших зондов. Перезаряжается медленно - активируйте для получения большого, но краткосрочного заряда.
+    #LOC_NFElectrical_capacitor-0625_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_capacitor-125_title = Блок конденсаторов CAR-8K
+    #LOC_NFElectrical_capacitor-125_description = Разместив 6 улучшенных CAP-102 на центральной опоре, можно создать встроенный блок конденсаторов приличного размера. Дополнительно, он может с лёгкостью погасить все огни в ЦУПе!
+    #LOC_NFElectrical_capacitor-125_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_capacitor-25_title = Блок конденсаторов CAR-EXTRA 
+    #LOC_NFElectrical_capacitor-25_description = Это мощный блок конденсаторов, который может сбросить достаточный заряд, чтобы даже самые большие двигатели проработали целых... э-э-э... 10 секунд.
+    #LOC_NFElectrical_capacitor-25_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_capacitor-radial-0625_title = Конденсатор CAP-101
+    #LOC_NFElectrical_capacitor-radial-0625_description =  CAP-101 - это конденсатор поверхностного монтажа. Заряжается медленно, но когда переключится, то быстро передаст всё накопленное электричество вашей системе аккумуляторов.
+    #LOC_NFElectrical_capacitor-radial-0625_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
+    #LOC_NFElectrical_capacitor-radial-0625-2_title = Конденсатор CAP-106
+    #LOC_NFElectrical_capacitor-radial-0625-2_description = CAP-106 это более мощный конденсатор поверхностного монтажа, использующий три новых модуля CAP-3A. Они слегка сплющены после того как полежали под несколькими ящиками с "Грохотами".
+    #LOC_NFElectrical_capacitor-radial-0625-2_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
+
+    // Reactors
+    #LOC_NFElectrical_reactor-0625_title = MX-0 Ядерный реактор "КербоМощь"
+    #LOC_NFElectrical_reactor-0625_description = Малый экспериментальный ядерный реактор, использующий двигатель Стирлинга и ограниченную реакцию распада для производства нескольких киловатт электроэнергии. Сделать его чуть больше - и у нас уже будет полноценный реактор!
+    #LOC_NFElectrical_reactor-0625_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission kilopower
+    #LOC_NFElectrical_reactor-125_title = MX-1 Ядерный реактор "Гранат"
+    #LOC_NFElectrical_reactor-125_description = MX-1 это компактный ядерный реактор, производящий до 400 кВт электроэнергии. Перед запуском убедитесь, что подключили к нему достаточно радиаторов!
+    #LOC_NFElectrical_reactor-125_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission topaz safe
+    #LOC_NFElectrical_reactor-25_title = MX-2S Ядерный реактор "Прометей"
+    #LOC_NFElectrical_reactor-25_description = Ядерный реактор MX-2S это рабочая лошадка, производящая шокирующие 2 МВт электроэенергии. Ничем не выдающийся, но всё же шаг по дороге к величию.
+    #LOC_NFElectrical_reactor-25_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
+    #LOC_NFElectrical_reactor-25-2_title =  MX-2L Ядерный реактор "Экскалибур"
+    #LOC_NFElectrical_reactor-25-2_description = Ядерный реактор MX-2L - второй по величине из доступных по площади. Он не только производит больше энергии чем родственный ему MX-2S, но и делает это с большей эффективностью, что выражается в меньшей массе необходимых радиаторов.
+    #LOC_NFElectrical_reactor-25-2_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
+    #LOC_NFElectrical_reactor-375_title = MX-3S Ядерный реактор Б.Л.И.Н.
+    #LOC_NFElectrical_reactor-375_description = Успех усовершенствованных генераторов в MX-2L позволил производителям переделать старые ядра MX-2S и продавать их снова с улучшенной секцией генераторов. Б.Л.И.Н. - один из наиболее энергоэффективных и надёжных реакторов из когда-либо построенных, и сочетает это с чрезвычайно щедрой загрузкой ядерного топлива, что позволяет обеспечить беспрецедентный срок службы ядра.
+    #LOC_NFElectrical_reactor-375_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
+    #LOC_NFElectrical_reactor-375-2_title = MX-3L Ядерный реактор "Гермес"
+    #LOC_NFElectrical_reactor-375-2_description = Масштабирование ядерных технологий совершенно иного порядка. Инженеры говорят, что это из области "долететь до Дюны за 30 дней на электрических двигателях".
+    #LOC_NFElectrical_reactor-375-2_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission
+
+
+    // Resources
+    #LOC_NFElectrical_nuclear-recycler-25_title =  Обогатительная Центрифуга "Волчок"
+    #LOC_NFElectrical_nuclear-recycler-25_description = Эта центрифуга может перерабатывать как Руду, так и Отработанное Топливо в Обогащённый Уран или извлекать Ксенон как побочный продукт распада. Оба процесса потребляют большое количество энергии и требуют мощного охлаждения.
+    #LOC_NFElectrical_nuclear-recycler-25_tags = conver isru mine )mining (ore process resource uranium refine reprocess nuclear nuke nearfuture
+    #LOC_NFElectrical_nuclear-recycler-25_USI_description = Эта центрифуга может перерабатывать Отработанное Топливо в Обогащённый Уран или извлекать Ксенон как побочный продукт распада. Оба процесса потребляют большое количество энергии и требуют мощного охлаждения.
+    #LOC_NFElectrical_nuclearfuel-0625_title = MF-0 Бочка для ядерного топлива
+    #LOC_NFElectrical_nuclearfuel-0625_description = Этот маленький но неплохо экранированный контейнер, возможно, пригоден для хранения небольших объёмов ядерного топлива.
+    #LOC_NFElectrical_nuclearfuel-0625_tags = atom nuclear nuke power reactor uranium shielded nearfuture
+    #LOC_NFElectrical_nuclearfuel-125_title = MF-1 Бочка для ядерного топлива
+    #LOC_NFElectrical_nuclearfuel-125_description = Среднего размера контейнер для хранения ядерного топлива и ядерных отходов.
+    #LOC_NFElectrical_nuclearfuel-125_tags = atom nuclear nuke power reactor uranium shielded nearfuture
+    #LOC_NFElectrical_nuclearfuel-25_title = MF-2 Бочка для ядерного топлива
+    #LOC_NFElectrical_nuclearfuel-25_description = Большой контейнер для хранения ядерных отходов и топлива.
+    #LOC_NFElectrical_nuclearfuel-25_tags = atom nuclear nuke power reactor uranium shielded nearfuture
+
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumProcessor_name = Переработчик урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumProcessor_StartAction = Начать переработку
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumProcessor_StopAction = Остановить переработку
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumProcessor_ToggleAction = Переключить переработку
+
+    #LOC_NFElectrical_nuclear-recycler-25_XenonExtractor_name = Извлекатель ксенона
+    #LOC_NFElectrical_nuclear-recycler-25_Xenonxtractor_StartAction = Начать извлечение ксенона
+    #LOC_NFElectrical_nuclear-recycler-25_XenonExtractor_StopAction = Остановить извлечение ксенона
+    #LOC_NFElectrical_nuclear-recycler-25_XenonExtractor_ToggleAction = Переключить извлечение ксенона
+
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumExtractor_name = Извлекатель урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumExtractor_StartAction = Начать извлечение урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumExtractor_StopAction = Остановить извлечение урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumExtractor_ToggleAction = Переключить извлечение урана
+
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumRefiner_name = Очиститель урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumRefiner_StartAction = Запустить очистку урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumRefiner_StopAction = Остановить очистку урана
+    #LOC_NFElectrical_nuclear-recycler-25_UraniumRefiner_ToggleAction = Переключить очиститель урана
+
+
+    // Other
+    #LOC_NFElectrical_rtg-0625_title = PB-AS-NUK Радиоизотопный генератор
+    #LOC_NFElectrical_rtg-0625_description = Используя большее количество Блутония-238 чем PB-NUK и более эффективную систему преобразования энергии, основанную на технологии, реверс-инжинированной с генератора производсвта Пост-Кербин, инженеры Ionic Symphonic довели до совершенства этот продвинутый РИТЭГ, обеспечивающий дорогое, но постоянное питание.
+    #LOC_NFElectrical_rtg-0625_tags = active atom charge e/c elect energ generat isotope nuclear nuke power radio rtg thermo volt watt nearfuture
+
+
+
+    // PLUGIN
+    // ModuleDischargeCapacitor
+	#LOC_NFElectrical_ModuleDischargeCapacitor_ModuleName = Конденсатор
+	#LOC_NFElectrical_ModuleDischargeCapacitor_PartInfo = Максимальный темп разряда: <<1>>ЭЭ/с \nТемп зарядки: <<2>>ЭЭ/с \nЭффективность: <<3>>%
+
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_ToggleUI = Переключить панель конденсатора
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_ToggleCharge = Переключить зарядку
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_EnableCharge = Разрешить зарядку
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_DisableCharge = Запретить зарядку
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Action_Discharge = Разрядить конденсатор
+
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_Discharge = Разрядить конденсатор
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_EnableCharge = Разрешить зарядку
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Event_DisableCharge = Запретить зарядку
+
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_DischargeRate = Темп разряда
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status = Состояние
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Discharging = Разряжается
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Charging = Заряжается
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_NoPower = Не хватает Электроэнергии!
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Ready = Готов
+	#LOC_NFElectrical_ModuleDischargeCapacitor_Field_Status_Empty = Разряжен
+
+	// ModuleFissionReactor
+	#LOC_NFElectrical_ModuleFissionReactor_ModuleName = Ядерный Реактор
+	#LOC_NFElectrical_ModuleFissionReactor_PartInfo = Требуется Охлаждение: <<1>> кВт \n\n<color=#99ff00>Параметры температуры:</color>\n- Оптимально: <<2>> К \n- Повреждение ядра: > <<3>> К\n- Расплав ядра: <<4>> К\n\nОжидаемый срок службы: <<5>>
+	#LOC_NFElectrical_ModuleFissionReactor_Action_TogglePanelAction = Переключить панель реактора
+
+	#LOC_NFElectrical_ModuleFissionReactor_Action_StartActionName = Запустить реактор
+	#LOC_NFElectrical_ModuleFissionReactor_Action_ToggleActionName = Запустить/Заглушить реактор
+	#LOC_NFElectrical_ModuleFissionReactor_Action_StopActionName = Заглушить реактор
+
+	#LOC_NFElectrical_ModuleFissionReactor_Event_ShowReactorControl = Переключить управление реактором
+	#LOC_NFElectrical_ModuleFissionReactor_Event_RepairReactor = Починить реактор
+
+	#LOC_NFElectrical_ModuleFissionReactor_Message_Repair_RepairSuccess = Реактор отремонтирован до <<1>>%!
+	#LOC_NFElectrical_ModuleFissionReactor_Message_Repair_CoreTooDamaged = Ядро реактора слишком повреждено для починки
+	#LOC_NFElectrical_ModuleFissionReactor_Message_Repair_CoreAlreadyRepaired = Состояние ядра реактора максимально возможное для починки в полевых условиях (<<1>>%)
+	#LOC_NFElectrical_ModuleFissionReactor_Message_Repair_EngineerLevelTooLow = Починка ядра реактора Требует инженера <<1>> уровня
+	#LOC_NFElectrical_ModuleFissionReactor_Message_Repair_NotWhileRunning = Нельзя чинить активное ядро!
+	#LOC_NFElectrical_ModuleFissionReactor_Message_Repair_CoreTooHot = Реактор должен быть холоднее <<1>> К чтобы начать ремонт!
+
+	#LOC_NFElectrical_ModuleFissionReactor_Field_CurrentSafetyOverride = Температура автовыключения
+	#LOC_NFElectrical_ModuleFissionReactor_Field_CurrentPowerPercent = Настройки энергии
+	#LOC_NFElectrical_ModuleFissionReactor_Field_ReactorOutput = Мощность реактора
+	#LOC_NFElectrical_ModuleFissionReactor_Field_ReactorOutput_Meltdown = Ядро уничтожено
+	#LOC_NFElectrical_ModuleFissionReactor_Field_ReactorOutput_Offline = Реактор заглушен
+	#LOC_NFElectrical_ModuleFissionReactor_Field_ThermalTransfer = Доступная мощность
+	#LOC_NFElectrical_ModuleFissionReactor_Field_CoreTemp = Температура ядра
+	#LOC_NFElectrical_ModuleFissionReactor_Field_CoreStatus = Состояние ядра
+	#LOC_NFElectrical_ModuleFissionReactor_Field_CoreStatus_Meltdown = Расплавление ядра
+	#LOC_NFElectrical_ModuleFissionReactor_Field_FuelStatus = Срок службы ядра
+	#LOC_NFElectrical_ModuleFissionReactor_Field_FuelStatus_Meltdown = Ядро уничтожено
+	#LOC_NFElectrical_ModuleFissionReactor_Field_FuelStatus_Offline = Реактор заглушен
+	#LOC_NFElectrical_ModuleFissionReactor_Field_FuelStatus_Exhausted = Топлива не осталось
+	#LOC_NFElectrical_ModuleFissionReactor_Field_FuelStatus_VeryLong = Почти вечность
+
+	// FissionGenerator
+	#LOC_NFElectrical_ModuleFissionGenerator_ModuleName = Генератор реактора
+	#LOC_NFElectrical_ModuleFissionGenerator_PartInfo = Произведено энергии: <<1>> ЭЭ/с
+	#LOC_NFElectrical_ModuleFissionGenerator_Field_GeneratorStatus = Генерирует
+	#LOC_NFElectrical_ModuleFissionGenerator_Field_GeneratorStatus_Offline = Выключен
+
+	// FissionFlowRadiator
+	#LOC_NFElectrical_ModuleFissionFlowRadiator_ModuleName = Охлаждение Выхлопом
+	#LOC_NFElectrical_ModuleFissionFlowRadiator_PartInfo = Охлаждение Выхлопом: <<1>> кВт\nПассивное охлаждение: <<2>> кВт
+	#LOC_NFElectrical_ModuleFissionFlowRadiator_Field_RadiatorStatus = Отводит Тепло
+
+	// RadioactiveStorageContainer
+	#LOC_NFElectrical_ModuleRadioactiveStorageContainer_ModuleName = Хранилище Ядерного Топлива
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_PartInfo = \n Позволяет хранить и перевозить радиоактивное топливо и отходы.
+  
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Event_TransferFuel = Переместить Топливо
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Event_TransferWaste = Переместить Отходы
+
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_StartTransfer = Щелкните левой кнопкой по модулю чтобы переместить ядерное топливо
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortEngineerLevel = Это перемещение требует наличия инженера <<1>> уровня на борту!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortFromRunningConverter = Нельзя перемещать из активного модуля переработки!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortToRunningConverter = Нельзя перемещать в активный модуль переработки!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortFromRunningReactor = Нельзя перемещать из запущенного реактора! Это плохая идея, серьёзно!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortToRunningReactor = Нельзя перемещать в запущенный реактор! Это плохая идея, серьёзно!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortTooHot = Температура модуля должна быть ниже <<1>> К чтобы перемещать содержимое!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortNoResource = В этом модуле нет <<1>> для перемещения!
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortNoPartSelected = Модуль не выбран, выходим из режима перемещения...
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortUnconnected = Нельзя переместить на несостыкованный аппарат, выходим из режима перемещения...
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_AbortNoRadStorage = Выбранный модуль не может хранить радиоактивные материалы, выходим из режима перемещения...
+  #LOC_NFElectrical_ModuleRadioactiveStorageContainer_Message_Success = "<<1>> <<2>> перемещено в контейнер!
+
+
+	// RadioisotopeGenerator
+	#LOC_NFElectrical_ModuleRadioisotopeGenerator_ModuleName = Радиоизотопный Генератор
+  #LOC_NFElectrical_ModuleRadioisotopeGenerator_PartInfo = Постоянно производит электроэнергию, но теряет мощность со временем \n\nПроизведено энергии: <<1>> ЭЭ/с \nПолураспад: <<2>> лет
+
+  #LOC_NFElectrical_ModuleRadioisotopeGenerator_Field_HalfLife = Полураспад
+  #LOC_NFElectrical_ModuleRadioisotopeGenerator_Field_PercentPower  = Эффективность
+  #LOC_NFElectrical_ModuleRadioisotopeGenerator_Field_ActualPower = Выходная Мощность
+
+	// Capacitor UI
+	#LOC_NFElectrical_CapacitorUI_Title = Панель Управления Конденсатора
+	#LOC_NFElectrical_CapacitorUI_SummaryRecharge = Заряжать, используя
+	#LOC_NFElectrical_CapacitorUI_SummaryDischarge = Разряжать при
+	#LOC_NFElectrical_CapacitorUI_NotInstalled = Конденсаторы не найдены!
+
+	// Reactor UI
+	#LOC_NFElectrical_ReactorUI_Title = Панель Управления Реактора
+	#LOC_NFElectrical_ReactorUI_Customize_Title = Панель Управления Реактора
+	#LOC_NFElectrical_ReactorUI_NotInstalled = Реакторы не обнаружены!
+	#LOC_NFElectrical_ReactorUI_AdvancedControls = ПРОДВИНУТЫЕ НАСТРОЙКИ
+  }


### PR DESCRIPTION
1. Real world capacitors ("конденсаторы") physicaly cannot behave like those fictional "Capacitors". 
Ionistors ("supercapacitors" in USA english IIRC) seem to be the closest real world analogue, having limitless cycles and allowing "slow" discharge, but they are much less mass-efficient than generic batteries (opposite to game "Capacitors")...
Maybe I should use a neutral word "накопитель" which is not linked to any exact energy storage method? (english word is "accumulator", don't confuse with russian "аккумулятор" which literally means "rechargeable battery")  
Final decision depends on what exact near-future technology do you have in mind for that "capacitors"? 

2. Do you mean something in particular with those manufacturer names? Or are they just "something random sounding proper"? Close-to literal russian counterparts sound weird.

3. #LOC_NFElectrical_battery-25_description uses "Batt Man Batteries" instead of "Batt-Direct Batteries" - is it a typo or what? 

4. I know, the proper russian word for refinement is "аффинаж" (fr->en "affination"), but there are tons of kids playing KSP - they won't understand it. So it's just a mundane term "очистка".

5. #LOC_NFElectrical_rtg-0625_description - Are you sure it must be "Blutonium" instead of plutonium? Uranium is written properly in other descriptions.

6. #LOC_NFElectrical_nuclearfuel-0625_title and others - there is no good russian word for drum-shaped container. Literal translation would be either "барабан" (percussion instrument or brake drum) or "стальная бочка" ("steel barrel").

7. #LOC_NFElectrical_reactor-0625_description - Considering description, MX-0 is not a proper reactor. So, what is it? ASRG (radioisotope stirling generator)? Description should be a bit different for ASRG.

8. But PB-AS-NUK part does look much more like ASRG prototype. Shouldn't #LOC_NFElectrical_rtg-0625_description have a description with Stirling engine instead? 

9. #LOC_NFElectrical_reactor-375_title - all adjectives are too long. Translated as "Б.Л.И.Н." - literally "pancake". =^_^=

10. Ingame testing shown that units of measurement are not translated. kW, SC/s and EC/s are still english both in part info and in control panels. Though I'm already a bit worried about SC abbreviation... russian one looks like "ХЗ" (Хранимый Заряд) which is kinda weird, as it may be misinterpreted for obscene abbreviation of "хуй знает" (literally "dick knows"). 
Oh! I have an idea. "НЗ" (Накопленный Заряд) - it still can be misinterpreted for "emergency rations", but rations are not obscene. =^_^=

11. In part info (capacitors) there is shown "/s" instead of expected "SC/s" while charging. In control panel it's shown correct.