### PR TITLE
removed desc numbers

### DIFF
--- a/GameData/NearFutureElectrical/Localization/en-us.cfg
+++ b/GameData/NearFutureElectrical/Localization/en-us.cfg
@@ -19,10 +19,10 @@ Localization
     // PARTS
     // Batteries
     #LOC_NFElectrical_battery-0625_title = B-3K Rechargeable Battery Bank
-    #LOC_NFElectrical_battery-0625_description = The biggest selling point of the B-3K is its reliance on 28 AAAA batteries, for redundancy. Note, unit may not operate with any dead batteries present. Do not attempt to remove batteries while running.
+    #LOC_NFElectrical_battery-0625_description = The biggest selling point of the bank is its reliance on 28 AAAA batteries, for redundancy. Note, unit may not operate with any dead batteries present. Do not attempt to remove batteries while running.
     #LOC_NFElectrical_battery-0625_tags = cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_battery-125_title = B-6K Rechargeable Battery Bank
-    #LOC_NFElectrical_battery-125_description = The B-6K is generally more reliable than the B-3K, because it uses the less accident-prone E batteries in its inline mount. Batt-Direct also advertises replacement capability for each battery, but recommends that this not be done by anyone outside of Batt-Direct. And certainly not in space.
+    #LOC_NFElectrical_battery-125_description = The 6K battery is generally more reliable than the 3K battery, because it uses the less accident-prone E batteries in its inline mount. Batt-Direct also advertises replacement capability for each battery, but recommends that this not be done by anyone outside of Batt-Direct. And certainly not in space.
     #LOC_NFElectrical_battery-125_tags = cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_battery-25_title = B-12K Rechargeable Battery Bank
     #LOC_NFElectrical_battery-25_description = In order to undercut Zaltonic Electronics, Batt Man Batteries has begun selling its largest 12K battery pack at wholesale prices directly to the KSC. A key selling point? The integrated ladder.
@@ -45,10 +45,10 @@ Localization
     #LOC_NFElectrical_capacitor-25_description = This is a potent capacitor bank, which can dump enough charge to run even the largest of engines for oh, up to 10 seconds.
     #LOC_NFElectrical_capacitor-25_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_capacitor-radial-0625_title = CAP-101 Capacitor
-    #LOC_NFElectrical_capacitor-radial-0625_description =  The CAP-101 is a radially attachable discharge capacitor. Through slow to charge up, when triggered, it will rapidly deposit its stored charge into your Electric Charge banks.
+    #LOC_NFElectrical_capacitor-radial-0625_description = It is a radially attachable discharge capacitor. Through slow to charge up, when triggered, it will rapidly deposit its stored charge into your Electric Charge banks.
     #LOC_NFElectrical_capacitor-radial-0625_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_capacitor-radial-0625-2_title = CAP-106 Capacitor
-    #LOC_NFElectrical_capacitor-radial-0625-2_description =The CAP-106 is a more powerful radial capacitor using three of those new CAP-3A units. They're slightly flattened due to being stacked under a few boxes of Mainsails.
+    #LOC_NFElectrical_capacitor-radial-0625-2_description = It is a more powerful radial capacitor using three of those new units. They're slightly flattened due to being stacked under a few boxes of Mainsails.
     #LOC_NFElectrical_capacitor-radial-0625-2_tags = capacitor cell charge e/c elect pack power volt watt nearfuture
 
     // Reactors
@@ -56,16 +56,16 @@ Localization
     #LOC_NFElectrical_reactor-0625_description = A small experimental fission generator using Stirling pistons and a small fission reaction to generate a few kW of electricity. Any bigger than this and we'll need a proper reactor!
     #LOC_NFElectrical_reactor-0625_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission kilopower kerbopower
     #LOC_NFElectrical_reactor-125_title = MX-1 'GARNET' Fission Reactor
-    #LOC_NFElectrical_reactor-125_description = The MX-1 is a compact fission reactor that produces up to 400 kW of electric power. Be sure to attach enough heat radiation capacity to run it!
+    #LOC_NFElectrical_reactor-125_description = The GARNET is a compact fission reactor that produces up to 400 kW of electric power. Be sure to attach enough heat radiation capacity to run it!
     #LOC_NFElectrical_reactor-125_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission topaz safe garnet
     #LOC_NFElectrical_reactor-25_title = MX-2S 'Prometheus' Fission Reactor
-    #LOC_NFElectrical_reactor-25_description = The MX-2S is a workhorse fission reactor that produces a shocking 2 MW of electric power. Exceptional nowhere, but a step on the road to greatness.
+    #LOC_NFElectrical_reactor-25_description = The Prometheus is a workhorse fission reactor that produces a shocking 2 MW of electric power. Exceptional nowhere, but a step on the road to greatness.
     #LOC_NFElectrical_reactor-25_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission prometheus
     #LOC_NFElectrical_reactor-25-2_title =  MX-2L 'Excalibur' Fission Reactor
-    #LOC_NFElectrical_reactor-25-2_description = The MX-2L is the second-largest fission reactor available through sheer footprint. Not only does it produce more power than its cousin the MX-2S, it does so at a higher efficiency and so requires less additional radiator mass.
+    #LOC_NFElectrical_reactor-25-2_description = The Excalibur is the second-largest fission reactor available through sheer footprint. Not only does it produce more power than its cousin the MX-2S, it does so at a higher efficiency and so requires less additional radiator mass.
     #LOC_NFElectrical_reactor-25-2_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission excalibur
     #LOC_NFElectrical_reactor-375_title = MX-3S F.L.A.T. Fission Reactor
-    #LOC_NFElectrical_reactor-375_description = The success of the advanced generators in the MX-2L has allowed the manufacturers to refurbish old MX-2S cores and ship them again with an improved power generation section. The F.L.A.T. is the one of the most fuel efficient and reliable reactors ever built, and combines this with an extra generous loading of nuclear fuel to achieve unprecedented core lifetime.
+    #LOC_NFElectrical_reactor-375_description = The success of the advanced generators in the Excalibur has allowed the manufacturers to refurbish old Prometheus cores and ship them again with an improved power generation section. The F.L.A.T. is the one of the most fuel efficient and reliable reactors ever built, and combines this with an extra generous loading of nuclear fuel to achieve unprecedented core lifetime.
     #LOC_NFElectrical_reactor-375_tags = active atom charge e/c elect energ generat nuclear nuke power thermo volt watt reactor nearfuture fission flat
     #LOC_NFElectrical_reactor-375-2_title = MX-3L 'Hermes' Fission Reactor
     #LOC_NFElectrical_reactor-375-2_description = Scaling up nuclear technology by another order of magnitude, engineers say that this is about were we need to be to get to Duna in 30 days with electric engines.

--- a/GameData/NearFutureElectrical/Localization/en-us.cfg
+++ b/GameData/NearFutureElectrical/Localization/en-us.cfg
@@ -19,10 +19,10 @@ Localization
     // PARTS
     // Batteries
     #LOC_NFElectrical_battery-0625_title = B-3K Rechargeable Battery Bank
-    #LOC_NFElectrical_battery-0625_description = The biggest selling point of the bank is its reliance on 28 AAAA batteries, for redundancy. Note, unit may not operate with any dead batteries present. Do not attempt to remove batteries while running.
+    #LOC_NFElectrical_battery-0625_description = The biggest selling point of the battery bank is its reliance on 28 AAAA batteries, for redundancy. Note, unit may not operate with any dead batteries present. Do not attempt to remove batteries while running.
     #LOC_NFElectrical_battery-0625_tags = cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_battery-125_title = B-6K Rechargeable Battery Bank
-    #LOC_NFElectrical_battery-125_description = The 6K battery is generally more reliable than the 3K battery, because it uses the less accident-prone E batteries in its inline mount. Batt-Direct also advertises replacement capability for each battery, but recommends that this not be done by anyone outside of Batt-Direct. And certainly not in space.
+    #LOC_NFElectrical_battery-125_description = The 6K battery bank is generally more reliable than the 3K battery bank, because it uses the less accident-prone E batteries in its inline mount. Batt-Direct also advertises replacement capability for each battery, but recommends that this not be done by anyone outside of Batt-Direct. And certainly not in space.
     #LOC_NFElectrical_battery-125_tags = cell charge e/c elect pack power volt watt nearfuture
     #LOC_NFElectrical_battery-25_title = B-12K Rechargeable Battery Bank
     #LOC_NFElectrical_battery-25_description = In order to undercut Zaltonic Electronics, Batt Man Batteries has begun selling its largest 12K battery pack at wholesale prices directly to the KSC. A key selling point? The integrated ladder.


### PR DESCRIPTION
 > 8K = By mounting **six enhanced CAP-102s** on a central mount, a decently sized inline capacitor bank can be created. Additionally, it can easily blow out all of the lights at the KSC!
 > EXTRA = This is a potent capacitor bank, which can dump enough charge to run even the largest of engines for oh, up to 10 seconds.

Also looks like the CAP-8K and CAP-EXTRA descriptions are mixed up, because the EXTRA consist of 6 little capacitors (ZP-102), and the 8K is one (ZP-102). 
And EXTRA should be 6 * 8K = 42K, doesn't it?



~~maybe add ZP-102 separately as radial part, since you named it in the description?~~