### PR TITLE
Fix decay patch for PB-SRG Advanced RTG.

### DIFF
--- a/Extras/DecayingRTGs/NFElectricalRTGPatch.cfg
+++ b/Extras/DecayingRTGs/NFElectricalRTGPatch.cfg
@@ -11,7 +11,7 @@
     EasyMode = true
   }
 }
-@PART[nfe-rtg-asrtg-1]:FOR[NearFutureElectrical]
+@PART[nfe-rtg-asrg-1]:FOR[NearFutureElectrical]
 {
   @cost *= 0.5
   !MODULE[ModuleGenerator] {}


### PR DESCRIPTION
This PR fixes a config bug in which the `Extras/DecayingRTGs` patch didn't apply to one NFE generator. A typo in the part definition caused it to be named `*-asrg-*` instead of `*-asrtg-*`. Assuming that changing the internal name in a backward-compatible way is not worth it, the most expedient solution is to reproduce the typo in the patch.